### PR TITLE
Stabilize and bump to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "iterslide"
-version = "0.0.5"
+version = "1.0.0"
 authors = ["Noemi Lapresta <santiago.lapresta@gmail.com>"]
 readme = "README.md"
 keywords = ["iterator", "iter", "slide", "sliding", "window"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 rust-iterslide
 ===============
 
+[![Version](https://img.shields.io/crates/v/iterslide.svg)](https://crates.io/crates/iterslide)
+[![Docs](https://docs.rs/iterslide/badge.svg)](https://docs.rs/iterslide)
 [![Build Status](https://travis-ci.org/purpliminal/rust-iterslide.svg?branch=master)](https://travis-ci.org/purpliminal/rust-iterslide)
 
 This package implements a "sliding window" iterator.
@@ -13,9 +15,9 @@ extern crate iterslide;
 use iterslide::SlideIterator;
 
 fn main() {
-    let x: Vec<i8> = vec![1, 2, 3, 4, 5];
+    let v: Vec<i8> = vec![1, 2, 3, 4, 5];
 
-    for window in x.into_iter().slide(3) {
+    for window in v.slide(3) {
       println!("{:?}", window);
     }
 }
@@ -45,9 +47,3 @@ Contribution
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you shall be dual licensed as above, without any
 additional terms or conditions.
-
-Contributors
-----
-
-[@doomrobo](https://github.com/doomrobo) updated the code to run on the
-latest Rust version. Thanks, @doomrobo! :)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ use iterslide::SlideIterator;
 
 fn main() {
     let x: Vec<i8> = vec![1, 2, 3, 4, 5];
-    
+
     for window in x.into_iter().slide(3) {
       println!("{:?}", window);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,93 +1,120 @@
-use std::cmp::Ordering::{Greater, Equal, Less};
+//! A sliding-window iterator library. Usable with any `Iterator` or `IntoIterator` with clonable
+//! values.
+//! Example:
+//!
+//! ```
+//! # fn main() {
+//! use iterslide::SlideIterator;
+//! let v: Vec<i8> = vec![1, 2, 3, 4, 5];
+//!
+//! for window in v.slide(3) {
+//!   // window is a VecDeque<i8>
+//!   println!("{:?}", window);
+//! }
+//!
+//! /*
+//! Output:
+//! [1, 2, 3]
+//! [2, 3, 4]
+//! [3, 4, 5]
+//! */
+//! # }
 
+use std::collections::VecDeque;
+
+/// Slide is a sliding-window iterator. The `next` method returns a `VecDeque` representing the
+/// current window.
 pub struct Slide<T: Iterator<Item=A>, A> {
     iter: T,
     n: usize,
-    window: Vec<A>
+    window: VecDeque<A>
 }
-
-macro_rules! return_if(
-    ($cond:expr, $value:expr) => (
-        if $cond {
-            return $value;
-        }
-    );
-);
 
 impl<A: Clone, T: Iterator<Item=A>> Slide<T, A> {
     fn push_window(&mut self) -> bool {
-        let iter_next = self.iter.next();
-        let is_some = iter_next.is_some();
-
-        if is_some {
-            self.window.push(iter_next.unwrap());
+        match self.iter.next() {
+            Some(x) => {
+                self.window.push_back(x);
+                true
+            },
+            None => false,
         }
-
-        is_some
     }
 
     fn new(iter: T, n: usize) -> Slide<T, A> {
         Slide {
             iter: iter,
             n: n,
-            window: Vec::with_capacity(n + 1)
+            window: VecDeque::with_capacity(n)
         }
     }
 }
 
 impl<A: Clone, T: Iterator<Item=A>> Iterator for Slide<T, A> {
-    type Item = Vec<A>;
+    type Item = VecDeque<A>;
 
-    fn next(&mut self) -> Option<Vec<A>> {
-        return_if!(self.n == 0, None);
-        return_if!(!self.push_window(), None);
+    fn next(&mut self) -> Option<VecDeque<A>> {
+        if self.n == 0 {
+            return None;
+        }
 
-        loop {
-            let window_status = self.window.len().cmp(&self.n);
-
-            match window_status {
-                Greater => { self.window.remove(0); }
-                Equal => { return Some(self.window.clone()); }
-                Less => { return_if!(!self.push_window(), None); }
+        // Uninitialized case. Fill the first window
+        if self.window.len() == 0 {
+            while self.window.len() < self.n {
+                if !self.push_window() {
+                    return None;
+                }
             }
         }
+        // Otherwise, shift the window by 1
+        else {
+            self.window.pop_front();
+            if !self.push_window() {
+                return None;
+            }
+        }
+
+        Some(self.window.clone())
     }
 }
 
 pub trait SlideIterator<T: Iterator<Item=A>, A> {
+    /// Returns a sliding-window iterator
     fn slide(self, n: usize) -> Slide<T, A>;
 }
 
-impl<A: Clone, T: Iterator<Item=A>> SlideIterator<T, A> for T {
-    fn slide(self, n: usize) -> Slide<T, A> {
-        Slide::new(self, n)
+impl<A: Clone, T: IntoIterator<Item=A>> SlideIterator<T::IntoIter, A> for T {
+    fn slide(self, n: usize) -> Slide<T::IntoIter, A> {
+        Slide::new(self.into_iter(), n)
     }
 }
 
 #[test]
 fn test_slide() {
-    let mut slide_iter = vec![1i8, 2, 3, 4, 5].into_iter().slide(3);
-    assert_eq!(slide_iter.next().unwrap(), vec![1, 2, 3]);
-    assert_eq!(slide_iter.next().unwrap(), vec![2, 3, 4]);
-    assert_eq!(slide_iter.next().unwrap(), vec![3, 4, 5]);
+    // NB: Although the window is a VecDeque, we can still compare it to slices, since VecDeque
+    // implements PartialEq for a ton of types
+    let mut slide_iter = vec![1i8, 2, 3, 4, 5].slide(3);
+    assert_eq!(slide_iter.next().unwrap(), &[1, 2, 3]);
+    assert_eq!(slide_iter.next().unwrap(), &[2, 3, 4]);
+    assert_eq!(slide_iter.next().unwrap(), &[3, 4, 5]);
     assert!(slide_iter.next().is_none());
 }
 
 #[test]
 fn test_slide_equal_window() {
-    let mut slide_iter = vec![1i8, 2, 3, 4, 5].into_iter().slide(5);
-    assert_eq!(slide_iter.next().unwrap(), vec![1, 2, 3, 4, 5]);
+    let mut slide_iter = vec![1i8, 2, 3, 4, 5].slide(5);
+    assert_eq!(slide_iter.next().unwrap(), &[1, 2, 3, 4, 5]);
     assert!(slide_iter.next().is_none());
 }
 
 #[test]
 fn test_slide_zero_window() {
-    let mut slide_iter = vec![1i8, 2, 3, 4, 5].into_iter().slide(0);
+    let mut slide_iter = vec![1i8, 2, 3, 4, 5].slide(0);
     assert!(slide_iter.next().is_none());
 }
 
 #[test]
 fn test_slide_overlong_window() {
-    let mut slide_iter = vec![1i8, 2, 3, 4, 5].into_iter().slide(7);
+    let mut slide_iter = vec![1i8, 2, 3, 4, 5].slide(7);
     assert!(slide_iter.next().is_none());
 }


### PR DESCRIPTION
From @doomrobo's https://github.com/purpliminal/rust-iterslide/pull/6#issuecomment-315619261

> [...] I cleaned up some code and added docs. I also made two big changes, the second of which is technically a breaking change:

> 1. I implemented `SlideIterator` for `IntoIterator<Item=A> where A: clone`. This is strictly more general than the `Iterator<Item=a> where A: clone` implementation, since every `Iterator` is trivially `IntoIterator`. That means you can (but don't have to) drop all the `into_iter()` calls when using the library.
> 2. I made the window type a `VecDeque` instead of a `Vec` for efficiency. The `next` function normally pushes to the back of the internal window `Vec`, then pops an element off the front. This pop makes every element shift downwards. This is O(n) behavior on every iteration of the window iterator, where n is the window size. Using a `VecDeque`, we can do the same thing, but with O(1) behavior, since it's a ring buffer. We also don't really lose any functionality because `VecDeque`s are iterable, comparable to a ton of things, and can be turned into `Vec`s pretty easily.

> Let me know what you think. Also to check out the docs, you'll have to load it locally, since the docs.rs only points to versions published on crates.io.